### PR TITLE
Increase token header buffer size

### DIFF
--- a/src/aws.c
+++ b/src/aws.c
@@ -259,7 +259,7 @@ static char *aws_dynamo_get_canonicalized_headers(struct http_headers *headers) 
 
 int aws_post(struct aws_handle *aws, const char *aws_service, const char *target, const char *body) {
 	char iso8601_basic_date[128];
-	char token_header[1024];
+	char token_header[4096];
 	char host_header[256];
 	char authorization[256];
 	struct http_header hdrs[] = {


### PR DESCRIPTION
These changes are done at parent repo- https://github.com/devicescape/aws_dynamo/commit/49189c5f8e742039e5fc56dbb62d521c4d8c60ce

This is the fix for instance-auth issue,
`Apr  2 08:33:46 ip-172-17-69-201 nss_instanceauth[7962]: Failed to make request to DynamoDB
Apr  2 08:33:55 ip-172-17-69-201 nss_instanceauth[7966]: aws_dynamo_post: token header truncated: 1044
Apr  2 08:33:55 ip-172-17-69-201 nss_instanceauth[7966]: aws_dynamo_request: Post failed.`